### PR TITLE
Explicit error handling for layout not found

### DIFF
--- a/lib/exbars.js
+++ b/lib/exbars.js
@@ -27,6 +27,9 @@ function Exbars(options) {
     var layout = options.layout === false ? null : options.layout || this.defaultLayout;
     if(layout) {
       var layoutTemplate = this.compiledTemplates[path.join(this.viewsPath, 'layouts', layout + '.hbs')];
+      if (layoutTemplate === undefined) {
+        throw new Error('Failed to lookup layout "' + layout + '" in ' + path.join(this.viewsPath, 'layouts'));
+      }
       this.callerPath = filePath.replace(process.cwd() + '/' + this.viewsPath + '/', '');
       options.body = template(options);
       this.callerPath = 'layouts/' + layout + '.hbs';


### PR DESCRIPTION
In the existing implementation, if a layout isn't found, the error is a rather ambiguous `layoutTemplate is not a function`. This proposed change throws an error with information that could be useful for debugging.