### PR TITLE
Windows support

### DIFF
--- a/helpers/partial.js
+++ b/helpers/partial.js
@@ -6,7 +6,7 @@ module.exports = function(exbars) {
 
   return function(name, context) {
     var dirName = path.dirname(exbars.callerPath);
-    var partial = partials[path.join(dirName, name)] || partials[name] || partials['views/' + name];
+    var partial = partials[path.join(dirName, name)] || partials[name] || partials[path.join('views' + name)];
 
     if (partial === undefined)
       throw new Error('Failed to lookup partial "' + name + '" in: ' + exbars.callerPath);

--- a/index.js
+++ b/index.js
@@ -19,8 +19,7 @@ module.exports = function(options, callback) {
         break;
       case /^_[a-z0-9_-]+[^_].hbs$/i.test(fileStats.name):
         fs.readFile(path.join(root, fileStats.name), function(err, data) {
-          exbars.registerPartial(root.replace(viewsPath + '/', '') + '/' +
-            string.snakeCase(path.basename(fileStats.name, '.hbs')), data.toString());
+          exbars.registerPartial(path.join(path.relative(viewsPath, root), string.snakeCase(path.basename(fileStats.name, '.hbs'))), data.toString());
           next();
         });
         break;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-var Exbars = require('./lib/exbars.js');
+var path = require('path');
+var Exbars = require(path.join(__dirname, 'lib/exbars.js'));
+var string = require('lodash/string');
 var walk = require('walk');
 var fs = require('fs');
-var path = require('path');
-var string = require('lodash/string');
 
 module.exports = function(options, callback) {
   var exbars = new Exbars(options);

--- a/lib/exbars.js
+++ b/lib/exbars.js
@@ -1,6 +1,6 @@
 var Handlebars = require('handlebars');
 var path = require('path');
-var partial = require('../helpers/partial');
+var partial = require(path.join(__dirname, '../helpers/partial.js'));
 
 function Exbars(options) {
   this.defaultLayout = options.defaultLayout || null;
@@ -23,19 +23,20 @@ function Exbars(options) {
   };
 
   this.render = function(filePath, options, callback) {
-    var template = this.compiledTemplates[filePath.replace(process.cwd() + '/', '')];
+	 filePath = path.normalize(filePath);
+    var template = this.compiledTemplates[path.relative(process.cwd(), filePath)];
     var layout = options.layout === false ? null : options.layout || this.defaultLayout;
     if(layout) {
       var layoutTemplate = this.compiledTemplates[path.join(this.viewsPath, 'layouts', layout + '.hbs')];
       if (layoutTemplate === undefined) {
         throw new Error('Failed to lookup layout "' + layout + '" in ' + path.join(this.viewsPath, 'layouts'));
       }
-      this.callerPath = filePath.replace(process.cwd() + '/' + this.viewsPath + '/', '');
+      this.callerPath =  path.relative(path.join(process.cwd(), this.viewsPath), filePath);
       options.body = template(options);
-      this.callerPath = 'layouts/' + layout + '.hbs';
+      this.callerPath = path.join('layouts', layout + '.hbs');
       return callback(null, layoutTemplate(options));
     }
-    this.callerPath = filePath.replace(process.cwd() + '/' + this.viewsPath + '/', '');
+    this.callerPath =  path.relative(path.join(process.cwd(), this.viewsPath), filePath);
     return callback(null, template(options));
   };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A flexible Handlebars view engine for Express",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover _mocha",
+    "test": "istanbul cover node_modules/mocha/bin/_mocha",
     "report-cov": "codeclimate-test-reporter < coverage/lcov.info"
   },
   "repository": {
@@ -22,15 +22,15 @@
   "author": "Youssef Kababe",
   "license": "MIT",
   "dependencies": {
-    "chai": "^3.5.0",
-    "handlebars": "^4.0.5",
-    "lodash": "^4.8.2",
-    "mixin-deep": "^1.1.3",
-    "walk": "^2.3.9"
+    "chai": "3.x",
+    "handlebars": "4.x",
+    "lodash": "4.x",
+    "mixin-deep": "1.x",
+    "walk": "2.x"
   },
   "devDependencies": {
-    "codeclimate-test-reporter": "^0.3.1",
-    "istanbul": "^0.4.3",
-    "mocha": "^2.4.5"
+    "codeclimate-test-reporter": "0.x",
+    "istanbul": "0.x",
+    "mocha": "2.x"
   }
 }

--- a/test/engine.js
+++ b/test/engine.js
@@ -1,5 +1,7 @@
+var path = require('path');
+var Engine = require(path.join(__dirname, '../index.js'));
 var should = require('chai').should();
-var Engine = require('../index');
+var os = require('os');
 
 describe('Engine', function() {
   var engine;
@@ -33,18 +35,18 @@ describe('Engine', function() {
 
   it('should render template with a partial in the same folder', function(done) {
     engine(process.cwd() + '/test/views/pages/index.hbs', {layout: false}, function(err, content) {
-      content.should.equal('<p>pages/index</p>\n<p>pages/links</p>');
+      content.should.equal('<p>pages/index</p>'+os.EOL+'<p>pages/links</p>');
       done();
     });
   });
 
   it('should render template with a partial in an another folder', function(done) {
     engine(process.cwd() + '/test/views/home.hbs', {layout: false}, function(err, content) {
-      content.should.equal('<p>home</p>\n<p>partials/widget</p>');
+      content.should.equal('<p>home</p>'+os.EOL+'<p>partials/widget</p>');
     });
 
     engine(process.cwd() + '/test/views/users/index.hbs', {layout: false}, function(err, content) {
-      content.should.equal('<p>users/index</p>\n<p>users/partials/widget</p>');
+      content.should.equal('<p>users/index</p>'+os.EOL+'<p>users/partials/widget</p>');
       done();
     });
   });

--- a/test/exbars.js
+++ b/test/exbars.js
@@ -1,5 +1,6 @@
+var path = require('path');
 var should = require('chai').should();
-var Exbars = require('../lib/exbars');
+var Exbars = require(path.join(__dirname, '../lib/exbars.js'));
 
 describe('Exbars', function() {
   var exbars = new Exbars({});
@@ -46,8 +47,8 @@ describe('Exbars', function() {
       exbars.compile('templateWithHelper', "<h1>{{someHelper 'hello'}}</h1>");
       exbars.compile('templateWithPartial', "<h1>{{partial 'some_partial'}}</h1>");
       exbars.compile('templateWithNFPartial', "<h1>{{partial 'not_found_partial'}}</h1>");
-      exbars.compile(exbars.viewsPath + '/layouts/main.hbs', '<div>{{{body}}}</div>');
-      exbars.compile(exbars.viewsPath + '/layouts/other.hbs', '<section>{{{body}}}</section>');
+      exbars.compile(path.join(exbars.viewsPath,  'layouts/main.hbs'), '<div>{{{body}}}</div>');
+      exbars.compile(path.join(exbars.viewsPath, 'layouts/other.hbs'), '<section>{{{body}}}</section>');
       exbars.registerHelper('someHelper', function(string) { return string.toUpperCase(); });
       exbars.registerPartial('some_partial', '<p>This is a partial</p>');
     });
@@ -116,7 +117,7 @@ describe('Exbars', function() {
       var fn = function() {
         exbars.render('templateWithNFPartial', {}, function(err, result) {});
       };
-      fn.should.throw('Failed to lookup partial "not_found_partial" in: pages/login.hbs');
+      fn.should.throw('Failed to lookup partial "not_found_partial" in: '+path.join('pages', 'login.hbs'));
     });
   });
 });


### PR DESCRIPTION
Original version of exbars doesn't work on Windows due to path differences within modules. Half of tests fail too. Adjusted paths all over the code (including tests) to fix it. Also updated dependencies in package.json just in case.
